### PR TITLE
Lagt til enkel idempotencysjekk

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/altinn/MeldingRepository.java
+++ b/src/main/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/altinn/MeldingRepository.java
@@ -92,10 +92,23 @@ public class MeldingRepository {
     }
 
     @Transactional
-    public void opprett(Melding melding) {
+    public void opprett(Melding melding, String idempotencyKey) {
         opprettMelding(melding);
+        opprettIdempotencyKey(idempotencyKey, melding);
         melding.getVedlegg().forEach(v -> opprettVedlegg(v, melding.getId()));
         melding.getOrganisasjoner().forEach(o -> opprettProsesseringsStatus(o, melding));
+    }
+
+    private void opprettIdempotencyKey(String idempotencyKey, Melding melding) {
+        MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource()
+                .addValue("melding_id", melding.getId())
+                .addValue("idempotency_key", idempotencyKey);
+        jdbcTemplate.update("insert into idempotency_melding (" +
+                "melding_id, " +
+                "idempotency_key) values (" +
+                ":melding_id, " +
+                ":idempotency_key)", mapSqlParameterSource
+                );
     }
 
     private void opprettProsesseringsStatus(String orgnr, Melding melding) {

--- a/src/main/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/altinn/MeldingRepository.java
+++ b/src/main/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/altinn/MeldingRepository.java
@@ -94,19 +94,16 @@ public class MeldingRepository {
     @Transactional
     public void opprett(Melding melding, String idempotencyKey) {
         opprettMelding(melding);
-        opprettIdempotencyKey(idempotencyKey, melding);
+        opprettIdempotencyKey(idempotencyKey);
         melding.getVedlegg().forEach(v -> opprettVedlegg(v, melding.getId()));
         melding.getOrganisasjoner().forEach(o -> opprettProsesseringsStatus(o, melding));
     }
 
-    private void opprettIdempotencyKey(String idempotencyKey, Melding melding) {
+    private void opprettIdempotencyKey(String idempotencyKey) {
         MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource()
-                .addValue("melding_id", melding.getId())
                 .addValue("idempotency_key", idempotencyKey);
         jdbcTemplate.update("insert into idempotency_melding (" +
-                "melding_id, " +
                 "idempotency_key) values (" +
-                ":melding_id, " +
                 ":idempotency_key)", mapSqlParameterSource
                 );
     }

--- a/src/main/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/altinn/api/MeldingController.java
+++ b/src/main/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/altinn/api/MeldingController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -35,12 +36,13 @@ public class MeldingController {
 
     @PostMapping("/melding")
     public ResponseEntity<HttpStatus> sendAltinnMelding(
-            @RequestBody AltinnMeldingDTO altinnMeldingDTO
+            @RequestBody AltinnMeldingDTO altinnMeldingDTO,
+            @RequestHeader("idempotency-key") String idempotencyKey
     ) {
         if (!harRettighet()) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
-        meldingRepository.opprett(altinnMeldingDTO.tilMelding());
+        meldingRepository.opprett(altinnMeldingDTO.tilMelding(), idempotencyKey);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/resources/db/migration/V8__idempotency_tabell.sql
+++ b/src/main/resources/db/migration/V8__idempotency_tabell.sql
@@ -1,0 +1,7 @@
+CREATE TABLE idempotency_melding (
+    melding_id      varchar(26),
+    idempotency_key varchar(26),
+    PRIMARY KEY (idempotency_key)
+);
+
+ALTER TABLE prosesserings_status ADD CONSTRAINT idempotency_melding_fk FOREIGN KEY ( melding_id ) REFERENCES melding ( id );

--- a/src/main/resources/db/migration/V8__idempotency_tabell.sql
+++ b/src/main/resources/db/migration/V8__idempotency_tabell.sql
@@ -1,7 +1,3 @@
 CREATE TABLE idempotency_melding (
-    melding_id      varchar(26),
-    idempotency_key varchar(26),
-    PRIMARY KEY (idempotency_key)
+    idempotency_key varchar(26) PRIMARY KEY
 );
-
-ALTER TABLE prosesserings_status ADD CONSTRAINT idempotency_melding_fk FOREIGN KEY ( melding_id ) REFERENCES melding ( id );

--- a/src/test/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/ApiAltinnErrorCodeTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/ApiAltinnErrorCodeTest.java
@@ -106,6 +106,7 @@ public class ApiAltinnErrorCodeTest {
                 HttpRequest.newBuilder()
                         .uri(URI.create("http://localhost:" + webAppPort + "/altinn-meldinger-api/melding"))
                         .header("Content-Type", "application/json")
+                        .header("idempotency-key", Ulider.nextULID())
                         .header("Authorization", "Bearer " + TestUtils.token(mockOAuth2Server, "aad", "subject", "altinn-meldinger-api", "rettighet-for-å-bruke-apiet-lokalt"))
                         .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(altinnMelding)))
                         .build(),

--- a/src/test/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/ApiAltinnServerErrorTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/ApiAltinnServerErrorTest.java
@@ -100,6 +100,7 @@ public class ApiAltinnServerErrorTest {
                 HttpRequest.newBuilder()
                         .uri(URI.create("http://localhost:" + webAppPort + "/altinn-meldinger-api/melding"))
                         .header("Content-Type", "application/json")
+                        .header("idempotency-key", Ulider.nextULID())
                         .header("Authorization", "Bearer " + TestUtils.token(mockOAuth2Server, "aad", "subject", "altinn-meldinger-api", "rettighet-for-å-bruke-apiet-lokalt"))
                         .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(altinnMelding)))
                         .build(),

--- a/src/test/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/ApiTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/ApiTest.java
@@ -115,6 +115,7 @@ public class ApiTest {
                 HttpRequest.newBuilder()
                         .uri(URI.create("http://localhost:" + webAppPort + "/altinn-meldinger-api/melding"))
                         .header("Content-Type", "application/json")
+                        .header("idempotency-key", Ulider.nextULID())
                         .header("Authorization", "Bearer " + TestUtils.token(mockOAuth2Server, "aad", "subject", "altinn-meldinger-api", "rettighet-for-å-bruke-apiet-lokalt"))
                         .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(altinnMelding)))
                         .build(),
@@ -164,6 +165,7 @@ public class ApiTest {
                         .uri(URI.create("http://localhost:" + webAppPort + "/altinn-meldinger-api/melding"))
                         .header("Content-Type", "application/json")
                         .header("Authorization", "Bearer " + TestUtils.token(mockOAuth2Server, "aad", "subject", "altinn-meldinger-api", "feilgruppe"))
+                        .header("idempotency-key", Ulider.nextULID())
                         .POST(HttpRequest.BodyPublishers.ofString("{}"))
                         .build(),
                 ofString()

--- a/src/test/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/altinn/MeldingRepositoryTest.java
+++ b/src/test/java/no/nav/arbeidsgiver/altinn/meldinger/altinnmeldinger/altinn/MeldingRepositoryTest.java
@@ -1,15 +1,18 @@
 package no.nav.arbeidsgiver.altinn.meldinger.altinnmeldinger.altinn;
 
+import no.nav.arbeidsgiver.altinn.meldinger.altinnmeldinger.Ulider;
 import no.nav.arbeidsgiver.altinn.meldinger.altinnmeldinger.altinn.domene.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @JdbcTest
 @ContextConfiguration(classes = MeldingRepository.class)
@@ -33,10 +36,25 @@ class MeldingRepositoryTest {
                     new Vedlegg("A2", "filinnhold2", "filnavn2", "vedleggnavn2"),
                     new Vedlegg("A3", "filinnhold3", "filnavn3", "vedleggnavn3")
             ));
+    public static final Melding TEST_MELDING_2 = new Melding(
+            "A2",
+            List.of("111111111", "222222222"),
+            "Melding",
+            "Tittel",
+            "systemUserCode",
+            "serviceCode",
+            "serviceEdition",
+            LocalDateTime.now().plusYears(2),
+            0,
+            List.of(
+                    new Vedlegg("A4", "filinnhold1", "filnavn1", "vedleggnavn1"),
+                    new Vedlegg("A5", "filinnhold2", "filnavn2", "vedleggnavn2"),
+                    new Vedlegg("A6", "filinnhold3", "filnavn3", "vedleggnavn3")
+            ));
 
     @Test
     public void hentProsesseringsstatus_metoder_skal_ta_hensyn_til_statuser() {
-        meldingRepository.opprett(TEST_MELDING);
+        meldingRepository.opprett(TEST_MELDING, Ulider.nextULID());
 
         assertThat(meldingRepository.hentMeldingerSomSkalSendesTilAltinn().size()).isEqualTo(2);
         assertThat(meldingRepository.hentMeldingerSomSkalSendesTilDokarkiv().size()).isEqualTo(0);
@@ -57,7 +75,7 @@ class MeldingRepositoryTest {
 
     @Test
     public void hentProsesseringsstatus_metoder_skal_bygge_ett_objekt_pr_prosesseringsrad() {
-        meldingRepository.opprett(TEST_MELDING);
+        meldingRepository.opprett(TEST_MELDING, Ulider.nextULID());
 
         List<MeldingsProsessering> prosesseringList = meldingRepository.hentMedStatus(AltinnStatus.IKKE_SENDT, JoarkStatus.IKKE_SENDT);
         assertThat(prosesseringList.size()).isEqualTo(2);
@@ -79,4 +97,21 @@ class MeldingRepositoryTest {
 
     }
 
+    @Test
+    public void opprett_melding_skal_ha_unik_idempotency_feil_hvis_ikke() {
+        String ulid = Ulider.nextULID();
+        meldingRepository.opprett(TEST_MELDING, ulid);
+        assertThat(meldingRepository.hentMeldingerSomSkalSendesTilAltinn().size()).isEqualTo(2);
+        assertThatThrownBy(() -> {
+            meldingRepository.opprett(TEST_MELDING_2, ulid);
+        }).isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    public void opprett_melding_skal_ha_unik_idempotency() {
+        meldingRepository.opprett(TEST_MELDING, Ulider.nextULID());
+        assertThat(meldingRepository.hentMeldingerSomSkalSendesTilAltinn().size()).isEqualTo(2);
+        meldingRepository.opprett(TEST_MELDING_2, Ulider.nextULID());
+        assertThat(meldingRepository.hentMeldingerSomSkalSendesTilAltinn().size()).isEqualTo(4);
+    }
 }


### PR DESCRIPTION
Jeg har lagd et forslag får enkel idempotency for å forhindre "dobbeltklikk" og dobbel utsendelse.

- Bruker en "idempotency-key" som er obligatorisk i header
- Feiler hvis samma key brukes to ganger